### PR TITLE
Global install option added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,4 +191,25 @@ elseif (ament_cmake_FOUND)
       DIRECTORY "include/"
       DESTINATION include
     )
+else()
+  #################################
+  ## General install configuration ##
+  #################################
+  include(GNUInstallDirs)
+  
+  install(TARGETS ${PROJECT_NAME}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+  install(DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.hpp")
+
+  if(BUILD_VGICP_CUDA)
+    install(TARGETS fast_vgicp_cuda
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+  endif()
 endif()


### PR DESCRIPTION
This pull request updates the installation configuration in `CMakeLists.txt` to improve compatibility and standardization when `ament_cmake` is not found. The changes add general install rules using CMake's recommended variables and ensure that both the main project and the optional CUDA target are installed correctly.

General install configuration improvements:

* Added use of `GNUInstallDirs` to standardize install destinations for libraries, archives, binaries, and headers, replacing hardcoded paths with CMake variables.
* Added installation rules for the main project target and header files, ensuring all relevant files are placed in the correct system locations.

Optional CUDA target installation:

* Added conditional installation rules for the `fast_vgicp_cuda` target when `BUILD_VGICP_CUDA` is enabled, ensuring CUDA components are installed only when built.